### PR TITLE
Attempt to fix invalid JSON after XSS changes

### DIFF
--- a/web/lib/Controller.pm
+++ b/web/lib/Controller.pm
@@ -1904,6 +1904,7 @@ sub local_query_preparsed {
 sub get_log_info {
 	my ($self, $args, $cb) = @_;
 	my $user = $args->{user};
+	$args->{q} =~ s/ /+/g;
 	
 	my $decode;
 	eval {


### PR DESCRIPTION
Clicking "Info" in non-grid view sends base64 encoded JSON with embedded space that causes error. Previous code had plus sign. Added one line of code before data is base64 decoded and parsed to replace spaces in base64 with '+' character.