### PR TITLE
Update Sphinx.pm

### DIFF
--- a/web/lib/Query/Sphinx.pm
+++ b/web/lib/Query/Sphinx.pm
@@ -490,7 +490,7 @@ sub _get_match_str {
 	$chars_indexed = join('', keys %$chars_indexed);
 	# Dash in the middle of $chars_indexed string is causing regex problems on new Perls (ie. Ubuntu 14.04)
 	$chars_indexed =~ s/-//g;
-	$chars_indexed = $chars_indexed .= "-";
+	$chars_indexed .= "-";
 	my $re = qr/[$chars_indexed]/i;
 	unless ($match_str =~ $re){
 		throw(400, 'Query did not contain any indexed characters.', { match_str => $match_str });


### PR DESCRIPTION
A literal dash, '-', in the middle of the string '$chars_indexed' is causing regex problems on new Perls (ie. Ubuntu 14.04).
On Ubuntu 14.04 with Perl 5.18.2, most queries return 500 error, " Invalid query result".
Problem was isolated to /usr/local/elsa/web/lib/Query/Sphinx.pm, line 491:
my $re = qr/[$chars_indexed]/i;

The string "$chars_indexed" contains a dash, '-', in random locations due to object keys being dumped to create the string.
The dash is being interpreted as a range operator in the character class in the regex.
When it falls between something like "j-4" or "9-4" it's failing due to being an invalid range.
In web.log and debugging in the browser you can see (with strategic logging lines added):
ret_q: $VAR1 = 'Invalid [] range "j-4" in regex

Adding two lines to remove the dash from the string, then appending a dash to the end of the string seems to work.
Now the dash should be treated as a character in the class and not as part of a range.