### PR TITLE
Move from Sphinx 2.1.3 to 2.1.9

### DIFF
--- a/contrib/install.sh
+++ b/contrib/install.sh
@@ -45,7 +45,7 @@ MYSQL_ROOT_PASS=""
 # These should be fine
 #SPHINX_VER="2.0.5-release"
 #SPHINX_VER="2.1.1-beta"
-SPHINX_VER="2.1.3-release"
+SPHINX_VER="2.1.9-release"
 EVENTLOG_VER="0.2.13"
 SYSLOG_VER="3.4.7"
 GEOIP_DIR="/usr/share/GeoIP/"


### PR DESCRIPTION
Sphinx 2.1.9 seems to be working fine so far:
https://groups.google.com/d/topic/enterprise-log-search-and-archive/Pdmhd0D2fso/discussion