### PR TITLE
Change Help hyperlink from Google Code to Github

### DIFF
--- a/web/inc/main.js
+++ b/web/inc/main.js
@@ -444,7 +444,7 @@ YAHOO.ELSA.main = function () {
 				{type:'text', args:'Query'},
 				{type:'input', args:{id:'q', name:'elsa_query_box', size:80} },
 				{type:'widget', className:'Button', args:oSubmitButtonConfig},
-				{type:'element', element:'a', args:{href:'http://code.google.com/p/enterprise-log-search-and-archive/wiki/Documentation#Queries', innerHTML:'Help', target:'_new'}}
+				{type:'element', element:'a', args:{href:'https://github.com/mcholste/elsa/wiki/Documentation#Queries', innerHTML:'Help', target:'_new'}}
 			]
 		];
 		


### PR DESCRIPTION
Change Help hyperlink from:
http://code.google.com/p/enterprise-log-search-and-archive/wiki/Documentation#Queries

to:
https://github.com/mcholste/elsa/wiki/Documentation#Queries