### PR TITLE
Check before use

### DIFF
--- a/web/lib/Query/Sphinx.pm
+++ b/web/lib/Query/Sphinx.pm
@@ -253,8 +253,8 @@ sub _get_groupby_clause {
 	my $self = shift;
 	my $class_id = shift;
 	
-	return '_groupby' if $self->groupby eq 'node'; 
 	return '' unless $self->groupby;
+	return '_groupby' if $self->groupby eq 'node'; 
 	return $self->_attr($self->groupby, $class_id);
 }
 


### PR DESCRIPTION
Check for existence of groupby before comparing its value.

Avoids recurring instances of "Use of uninitialized value in string eq at /opt/elsa/web/lib/Query/Sphinx.pm line 256." line in apache2 error log...